### PR TITLE
Add AnsiString column support

### DIFF
--- a/SharpMigrations/SchemaMigration.cs
+++ b/SharpMigrations/SchemaMigration.cs
@@ -23,6 +23,8 @@ namespace SharpMigrations {
                 fc.Object.IsAutoIncrement = true;
                 return fc;
             }
+            public static FluentColumn AnsiString(string name) { return new FluentColumn(name, DbType.AnsiString); }
+            public static FluentColumn AnsiString(string name, int size) { return new FluentColumn(name, DbType.AnsiString, size); }
             public static FluentColumn String(string name) { return SColumn.String(name); }
             public static FluentColumn String(string name, int size) { return SColumn.String(name, size); }
             public static FluentColumn Clob(string name) { return SColumn.Clob(name); }


### PR DESCRIPTION
This commit simplifies the creation of columns with DbType.AnsiString and make it work like the DbType.String case.

There are no SharpData.Schema.Column.AnsiString method (I made an pull request to support it), so the implementation returns a new instance of FluentColumn directly.